### PR TITLE
Adding 2 snippets that others may find helpful

### DIFF
--- a/map-email-to-user-field.php
+++ b/map-email-to-user-field.php
@@ -3,11 +3,11 @@
  * Plugin Name: Gravity Flow Library - Map email field to user field
  * Description: During form submission maps a user id into user field based on email field value
  * Version: 1.0
- * Author: Jamie Oastler
- * Author URI: http://idealienstudios.com
+ * Author: Steven Henty
+ * Author URI: https://gravityflow.io
  * License: GPL-3.0+
  *
- * Copyright 2018 Jamie Oastler
+ * Copyright 2019 Steven Henty
  *
  * Requires Gravity Flow 1.8.1+
  */
@@ -18,9 +18,9 @@ You want user, Gravity Forms CLI or other automation tool, to submit a form prov
 If you were to assign the step directly to email field they must access it via token which is not associated to the WP User despite user profile matching email.
 
 HOW WOULD I USE THIS SNIPPET?
-Copy and paste the code into your child theme's functions.php or place inside a custom functionality plugin.
-Create a form with email field and (likely) hidden user field.
-Replace defined variables ($form_id, $email_field_id, $user_field_id) with your workflow specific values to map the email field value to a hidden user field
+- Activate this plugin
+- Create a form with email field and (likely) hidden user field.
+- Replace defined variables ($form_id, $email_field_id, $user_field_id) with your workflow specific values to map the email field value to a hidden user field
 */
 
 add_action( 'gform_pre_submission', 'map_email_to_user_field', 10, 1 );

--- a/map-email-to-user-field.php
+++ b/map-email-to-user-field.php
@@ -1,0 +1,29 @@
+<?php
+//https://github.com/gravityflow/gravityflowlibrary
+
+/*
+WHEN WOULD I USE THIS SNIPPET?
+You want user, Gravity Forms CLI or other automation tool, to submit a form providing email address and have a step get assigned to their Wordpress user.
+If you were to assign the step directly to email field they must access it via token which is not associated to the WP User despite user profile matching email.
+
+HOW WOULD I USE THIS SNIPPET?
+Copy and paste the code into your child theme's functions.php or place inside a custom functionality plugin.
+Create a form with email field and (likely) hidden user field.
+Replace defined variables ($form_id, $email_field_id, $user_field_id) with your workflow specific values to map the email field value to a hidden user field
+*/
+
+add_action( 'gform_pre_submission', 'map_email_to_user_field', 10, 1 );
+
+function map_email_to_user_field( $form ) {
+
+    $form_id = '123';
+    $email_field_id = '456';
+    $user_field_id = '789';
+
+    if ( $form['id'] == $form_id && null !== rgpost( 'input_' . $email_field_id ) ) {
+        $user = get_user_by( 'email', rgpost( 'input_' . $email_field_id ) );
+        if ( $user ) {
+            $_POST['input_' . $user_field_id] = $user->ID;
+        }
+    }
+}

--- a/map-email-to-user-field.php
+++ b/map-email-to-user-field.php
@@ -1,9 +1,20 @@
 <?php
-//https://github.com/gravityflow/gravityflowlibrary
+/**
+ * Plugin Name: Gravity Flow Library - Map email field to user field
+ * Description: During form submission maps a user id into user field based on email field value
+ * Version: 1.0
+ * Author: Jamie Oastler
+ * Author URI: http://idealienstudios.com
+ * License: GPL-3.0+
+ *
+ * Copyright 2018 Jamie Oastler
+ *
+ * Requires Gravity Flow 1.8.1+
+ */
 
 /*
 WHEN WOULD I USE THIS SNIPPET?
-You want user, Gravity Forms CLI or other automation tool, to submit a form providing email address and have a step get assigned to their Wordpress user.
+You want user, Gravity Forms CLI or other automation tool, to submit a form providing email address and have a step get assigned to their WordPress user.
 If you were to assign the step directly to email field they must access it via token which is not associated to the WP User despite user profile matching email.
 
 HOW WOULD I USE THIS SNIPPET?
@@ -16,14 +27,14 @@ add_action( 'gform_pre_submission', 'map_email_to_user_field', 10, 1 );
 
 function map_email_to_user_field( $form ) {
 
-    $form_id = '123';
-    $email_field_id = '456';
-    $user_field_id = '789';
+	$form_id = '123';
+	$email_field_id = '456';
+	$user_field_id = '789';
 
-    if ( $form['id'] == $form_id && null !== rgpost( 'input_' . $email_field_id ) ) {
-        $user = get_user_by( 'email', rgpost( 'input_' . $email_field_id ) );
-        if ( $user ) {
-            $_POST['input_' . $user_field_id] = $user->ID;
-        }
-    }
+	if ( $form['id'] == $form_id && null !== rgpost( 'input_' . $email_field_id ) ) {
+		$user = get_user_by( 'email', rgpost( 'input_' . $email_field_id ) );
+		if ( $user ) {
+			$_POST[ 'input_' . $user_field_id ] = $user->ID;
+		}
+	}
 }

--- a/userinput-inprogress-skip-required-validation.php
+++ b/userinput-inprogress-skip-required-validation.php
@@ -1,5 +1,16 @@
 <?php
-//https://github.com/gravityflow/gravityflowlibrary
+/**
+ * Plugin Name: Gravity Flow Library - User Input skip required validation for in progress
+ * Description: Bypass required field validation on defined form/fields when saving in progress user input step
+ * Version: 1.0
+ * Author: Jamie Oastler
+ * Author URI: http://idealienstudios.com
+ * License: GPL-3.0+
+ *
+ * Copyright 2018 Jamie Oastler
+ *
+ * Requires Gravity Flow 1.8.1+
+ */
 /*
 WHEN WOULD I USE THIS SNIPPET?
 You have a large form with many fields that are required but you do not want to validate them during a user input step in progress.
@@ -13,24 +24,24 @@ add_filter( 'gravityflow_validation_user_input',  'workflow_inprogress_bypass_re
 
 function workflow_inprogress_bypass_required_fields( $validation_result, $step, $new_status ) {
 
-    $form_id = '123';
-    $step_id = '45';
+	$form_id = '123';
+	$step_id = '45';
 
-    if( ($validation_result['form']['id'] == $form_id && rgpost( 'step_id' ) == $step_id && $new_status == 'in_progress') ) {
+	if( ($validation_result['form']['id'] == $form_id && rgpost( 'step_id' ) == $step_id && $new_status == 'in_progress') ) {
 
-        $form = $validation_result['form'];
-        
-        foreach ( $form['fields'] as &$field ) {
-            $field->failed_validation = false;
-            $field->validation_message = '';
-        }
+		$form = $validation_result['form'];
 
-        $validation_result = array(
-            'is_valid' => true,
-            'form'     => $form,
-        );
+		foreach ( $form['fields'] as &$field ) {
+			$field->failed_validation = false;
+			$field->validation_message = '';
+		}
 
-    }
-    
-    return $validation_result;
+		$validation_result = array(
+			'is_valid' => true,
+			'form'     => $form,
+		);
+
+	}
+
+	return $validation_result;
 }

--- a/userinput-inprogress-skip-required-validation.php
+++ b/userinput-inprogress-skip-required-validation.php
@@ -1,0 +1,36 @@
+<?php
+//https://github.com/gravityflow/gravityflowlibrary
+/*
+WHEN WOULD I USE THIS SNIPPET?
+You have a large form with many fields that are required but you do not want to validate them during a user input step in progress.
+
+HOW WOULD I USE THIS SNIPPET?
+Copy and paste the code into your child theme's functions.php or place inside a custom functionality plugin.
+Replace defined variables ($form_id, $step_id) with your workflow specific values for a user input step with save progress setting active.
+*/
+
+add_filter( 'gravityflow_validation_user_input',  'workflow_inprogress_bypass_required_fields', 10, 3 );
+
+function workflow_inprogress_bypass_required_fields( $validation_result, $step, $new_status ) {
+
+    $form_id = '123';
+    $step_id = '45';
+
+    if( ($validation_result['form']['id'] == $form_id && rgpost( 'step_id' ) == $step_id && $new_status == 'in_progress') ) {
+
+        $form = $validation_result['form'];
+        
+        foreach ( $form['fields'] as &$field ) {
+            $field->failed_validation = false;
+            $field->validation_message = '';
+        }
+
+        $validation_result = array(
+            'is_valid' => true,
+            'form'     => $form,
+        );
+
+    }
+    
+    return $validation_result;
+}

--- a/userinput-inprogress-skip-required-validation.php
+++ b/userinput-inprogress-skip-required-validation.php
@@ -3,11 +3,11 @@
  * Plugin Name: Gravity Flow Library - User Input skip required validation for in progress
  * Description: Bypass required field validation on defined form/fields when saving in progress user input step
  * Version: 1.0
- * Author: Jamie Oastler
- * Author URI: http://idealienstudios.com
+ * Author: Steven Henty
+ * Author URI: https://gravityflow.io
  * License: GPL-3.0+
  *
- * Copyright 2018 Jamie Oastler
+ * Copyright 2019 Steven Henty
  *
  * Requires Gravity Flow 1.8.1+
  */
@@ -16,8 +16,8 @@ WHEN WOULD I USE THIS SNIPPET?
 You have a large form with many fields that are required but you do not want to validate them during a user input step in progress.
 
 HOW WOULD I USE THIS SNIPPET?
-Copy and paste the code into your child theme's functions.php or place inside a custom functionality plugin.
-Replace defined variables ($form_id, $step_id) with your workflow specific values for a user input step with save progress setting active.
+- Activate this plugin
+- Replace defined variables ($form_id, $step_id) with your workflow specific values for a user input step with save progress setting active.
 */
 
 add_filter( 'gravityflow_validation_user_input',  'workflow_inprogress_bypass_required_fields', 10, 3 );
@@ -27,7 +27,7 @@ function workflow_inprogress_bypass_required_fields( $validation_result, $step, 
 	$form_id = '123';
 	$step_id = '45';
 
-	if( ($validation_result['form']['id'] == $form_id && rgpost( 'step_id' ) == $step_id && $new_status == 'in_progress') ) {
+	if ( ( $validation_result['form']['id'] == $form_id && rgpost( 'step_id' ) == $step_id && $new_status == 'in_progress') ) {
 
 		$form = $validation_result['form'];
 


### PR DESCRIPTION
- **map-email-to-user-field**: A nice way to simplify GF CLI commands to create form by email address and be able to assign step to user instead of email (by token).

- **userinput-inprogress-skip-required-validation**: Doesn't the name just say it all? :) Leverages a to-be-documented filter of GFlow to bypass required field validation on specific user input step with save progress option enabled.
